### PR TITLE
Fixed memory leak in GauMatEl

### DIFF
--- a/include/gauinterface.h
+++ b/include/gauinterface.h
@@ -184,7 +184,7 @@ public:
   inline double *      cart(){return this->cart_;};
   inline double *      atmWgt(){return this->atmWgt_;};
 
-  void readRec(int,double*&,bool);
+  double * readRec(int);
 };
 
 #endif

--- a/src/aointegrals/aointegrals_twoe.cpp
+++ b/src/aointegrals/aointegrals_twoe.cpp
@@ -1149,10 +1149,10 @@ void AOIntegrals::twoEContract(bool doRHFFock, const RealMatrix &X, RealMatrix &
   #pragma omp parallel
   {
     int thread_id = omp_get_thread_num();
-    simple_twoe(thread_id);
+    efficient_twoe(thread_id);
   }
 #else
-  simple_twoe(0);
+  efficient_twoe(0);
 #endif
   for(int i = 0; i < this->controls_->nthreads; i++) AX += G[i];
 //RealMatrix Tmp = 0.5*(AX + AX.transpose());

--- a/src/gauinterface/gauinterface.cpp
+++ b/src/gauinterface/gauinterface.cpp
@@ -313,7 +313,7 @@ void GauMatEl::initHeader_(){
   for(auto i = 0; i < GauHeader.size(); i++)
     GauHeader[i].resize(LEN_GAU_STR,' ');
 }
-void GauMatEl::readRec(int rec, double*& data, bool alloc){
+double * GauMatEl::readRec(int rec){
   bool found = false;
 
   std::string FileTerm = "END";
@@ -351,15 +351,15 @@ void GauMatEl::readRec(int rec, double*& data, bool alloc){
       }
     }
     if(!Label.compare(GauHeader[rec])){
-      if(alloc){
-        delete [] data;
-        data = new double[NTot];
-      }
+      double *data = new double[NTot];
       for(auto i = 0; i < NTot; i++){
         data[i] = DX[i];
       }
      
       found = true;
+      delete [] ID;
+      delete [] DX;
+      return data;
       break; 
     }
     

--- a/src/singleslater/singleslater.cpp
+++ b/src/singleslater/singleslater.cpp
@@ -468,8 +468,7 @@ void SingleSlater::readGuessIO() {
 void SingleSlater::readGuessGauMatEl(GauMatEl& matEl){
   this->fileio_->out << "Reading MO coefficients from " <<matEl.fname()<< endl;
   if(matEl.nBasis()!=this->nBasis_) CErr("Basis Set mismatch",this->fileio_->out);
-  double *scr = NULL;
-  matEl.readRec(GauMatEl::moa,scr,true); 
+  double *scr = matEl.readRec(GauMatEl::moa); 
   for(auto i = 0; i < this->nBasis_*this->nBasis_; i++)
     this->moA_->data()[i] = scr[i];
   this->moA_->transposeInPlace();


### PR DESCRIPTION
Realized that the simple twoe contraction lambda is horrifically
inefficient (switched back to old efficient lambda)